### PR TITLE
DB init on app call, in app.js for Monkvision.

### DIFF
--- a/backend/apps/monkvision/lib/app.js
+++ b/backend/apps/monkvision/lib/app.js
@@ -2,4 +2,4 @@
  * (C) 2020 TekMonks. All rights reserved.
  */
 
-module.exports.initSync = _ => global.APP_CONSTANTS = require(`${__dirname}/../apis/lib/constants.js`);
+module.exports.initSync = _ => { global.APP_CONSTANTS = require(`${__dirname}/../apis/lib/constants.js`); require(`${APP_CONSTANTS.LIB_DIR}/db.js`).init(); }


### PR DESCRIPTION
**DB init function is called in app.js, to avoid errors in APIs.**

Queries in APIs call the getQuery().
The API who calls the getQuery() first time, fails with error: `dbAllAsync is not a function`

This happens because:

- in db.js, getQuery() initializes the DB, 
- but since all APIs are called asynchronously, 
- error gets thrown for dbAllAsync not being a function for one of the APIs.

![image](https://user-images.githubusercontent.com/77233449/106025603-ea0aee80-60ee-11eb-8987-898c8806a3ad.png)
  