### PR TITLE
DB init on app call, in app.js.

### DIFF
--- a/backend/apps/monkvision/lib/app.js
+++ b/backend/apps/monkvision/lib/app.js
@@ -2,4 +2,4 @@
  * (C) 2020 TekMonks. All rights reserved.
  */
 
-module.exports.initSync = _ => global.APP_CONSTANTS = require(`${__dirname}/../apis/lib/constants.js`);
+module.exports.initSync = _ => { global.APP_CONSTANTS = require(`${__dirname}/../apis/lib/constants.js`); require(`${APP_CONSTANTS.LIB_DIR}/db.js`).init(); }


### PR DESCRIPTION
Calling db.init() in app.js, so that DB initializes at app start.

Reopening PR - #4 