### PR TITLE
Added title mapping for components

### DIFF
--- a/frontend/apps/monkvision/components/chart-box/chart-box.mjs
+++ b/frontend/apps/monkvision/components/chart-box/chart-box.mjs
@@ -121,6 +121,8 @@ async function _refreshData(element, force) {
 		data.exportCSV = frameworkUtils.parseBoolean(element.getAttribute("exportCSV"));
 		if (data.exportCSV) data.exportCSVIcon = element.getAttribute("exportCSVIcon") || "./components/chart-box/img/download_icon.svg";
 		await bindData(data, id); if (!content || !content.contents) return;
+		 // Apply attack title mapping to x-axis labels and legend
+		["x", "legend"].forEach(k => { try { content.contents[k] = content.contents[k]?.map(l => APP_CONSTANTS.TITLE_MAPPING?.[l] ?? l); } catch {} });
 
 		const labels = _getLabels(_makeArray(element.getAttribute("ylabels")));
 		const labelColor = element.getAttribute("labelColor") || "black";

--- a/frontend/apps/monkvision/components/threat-status-card/threat-status-card.mjs
+++ b/frontend/apps/monkvision/components/threat-status-card/threat-status-card.mjs
@@ -57,7 +57,7 @@ async function _refreshData(element, force) {
         if (content.contents.attacks) {
             data.attacks = content.contents.attacks.map(attack => ({
                 ...attack,
-                name: attack.name,
+                name: APP_CONSTANTS.TITLE_MAPPING?.[attack.name] ?? attack.name,
                 isSafe: attack.status === 'SAFE'
             }));
         }

--- a/frontend/apps/monkvision/conf/titleMapping.json
+++ b/frontend/apps/monkvision/conf/titleMapping.json
@@ -1,0 +1,3 @@
+{
+    "example_mon": "Example Mon"
+}

--- a/frontend/apps/monkvision/js/constants.mjs
+++ b/frontend/apps/monkvision/js/constants.mjs
@@ -8,9 +8,10 @@ const APP_NAME = "monkvision";
 const APP_PATH = `${FRONTEND}/apps/${APP_NAME}`;
 const API_PATH = `${BACKEND}/apps/${APP_NAME}`;
 const CONF_PATH = `${APP_PATH}/conf`;
+const TITLE_MAPPING = await $$.requireJSON(`/apps/monkvision/conf/titleMapping.json`, true).catch(() => ({}));
 
 export const APP_CONSTANTS = {
-    FRONTEND, BACKEND, APP_PATH, APP_NAME, API_PATH,CONF_PATH,
+    FRONTEND, BACKEND, APP_PATH, APP_NAME, API_PATH,CONF_PATH, TITLE_MAPPING,
     INDEX_HTML: APP_PATH+"/index.html",
     MAIN_HTML: APP_PATH+"/main.html",
     LOGIN_HTML: APP_PATH+"/login.html",


### PR DESCRIPTION
This includes name/title mapping for `chart-box` and `threat-status-card` component rather than mon names.
Before:

<img width="893" height="411" alt="image" src="https://github.com/user-attachments/assets/16d9a0ec-7c21-40ea-8079-2a48aa0742d3" />
After adding title mapping for components:

<img width="888" height="400" alt="image" src="https://github.com/user-attachments/assets/2166192d-0789-45dc-a3ea-570e562b293f" />
