### PR TITLE
[FIX] Critical Alerts Visibility

### DIFF
--- a/frontend/apps/monkvision/conf/theme_dark.json
+++ b/frontend/apps/monkvision/conf/theme_dark.json
@@ -120,6 +120,7 @@
         "exportCSVIcon": "./img/download_icon.svg",
         "AlertsBackground":"#505050",
         "AlertsBackgroundLight":"#9e9e9e",
+        "TextContent": "#ffffff",
         "BannerOKColors":"#ffffff,#45d19e",
         "BannerElseColors": "#ffffff,#ff3f3fcc",
         "BannerElseIcon": "./img/server_icon.svg",

--- a/frontend/apps/monkvision/conf/theme_light.json
+++ b/frontend/apps/monkvision/conf/theme_light.json
@@ -122,6 +122,7 @@
         "dashicon": "./img/dashicon.svg",
         "AlertsBackground":"#ebfaf5",
         "AlertsBackgroundLight":"#c5ffc7",
+        "TextContent": "#000000",
         "BannerOKColors":"#ffffff,#45d19e",
         "BannerElseColors": "#ffffff,#ff3f3fcc",
         "BannerElseIcon": "./img/server_icon.svg",

--- a/frontend/apps/monkvision/dashboards/dashboard_demo.page
+++ b/frontend/apps/monkvision/dashboards/dashboard_demo.page
@@ -3,7 +3,7 @@ SCHEMA
 {
     "alerts": {"html":"chart-box", "id":"alerts", "title":"{{i18n.CriticalAlerts}}", "api":"alerts", 
         "type":"text",
-        "styleBody":"div#container{height: calc(100vh - 105px) !important;} div#container > p {margin-bottom: 0.8em;} div#content {height: calc(100% - 26em);} div#textcontent:nth-child(odd){background-color:{{AlertsBackground}}} div#textcontent:nth-child(even){background-color:{{AlertsBackgroundLight}}} div#content > div#textcontent > span#text > p:hover {background-color: unset}"},
+        "styleBody": "html, body { background-color: {{AlertsBackground}}; color: {{TextContent}};} div#container { height: calc(100vh - 105px); background-color: {{AlertsBackground}};} div#container > p { margin-bottom: 0.8em; color: {{TextContent}};} div#content { height: calc(100% - 26em); background-color: {{AlertsBackground}};} div#content > div#textcontent { color: {{TextContent}}; padding: 4px 0;} div#content > div#textcontent:nth-child(odd) { background-color: {{AlertsBackground}};} div#content > div#textcontent:nth-child(even) { background-color: {{AlertsBackgroundLight}};} div#content > div#textcontent > span#text > p { color: {{TextContent}}; margin: 0; padding: 10px;} div#content > div#textcontent > span#text > p:hover { background-color: transparent;}"},
 
  
     "httpBar": {"html":"chart-box", "id":"httpBar", "title":"Nginx Server", "api":"loggraph", 


### PR DESCRIPTION
### Fix: Critical Alerts component theme-aware styling

- Alternating row backgrounds now correctly stripe per alert entry using div#textcontent:nth-child selectors, matching the actual DOM structure rendered by the Mustache template
- Text and background colors are fully driven by theme tokens (AlertsBackground, AlertsBackgroundLight, TextContent) — no hardcoded colors in the schema
- Hover no longer overrides row background; uses transparent to inherit the correct stripe color from the parent

**Before:** 
<img width="618" height="353" alt="image" src="https://github.com/user-attachments/assets/e0a742ba-ba74-410e-b2ee-1aeda40508ef" />
<br>
**After:** 
<img width="871" height="440" alt="image" src="https://github.com/user-attachments/assets/27719f3f-1f93-4943-b103-b42c7176b614" />
