### PR TITLE
fix: resolve empty {{i18n.*}} placeholders after logout

### DIFF
--- a/frontend/apps/monkvision/js/loginmanager.mjs
+++ b/frontend/apps/monkvision/js/loginmanager.mjs
@@ -6,6 +6,7 @@ import {application} from "./application.mjs";
 import {session} from "/framework/js/session.mjs";
 import {securityguard} from "/framework/js/securityguard.mjs";
 import {apimanager as apiman} from "/framework/js/apimanager.mjs";
+import {i18n} from "/framework/js/i18n.mjs";
 
 let currTimeout; let logoutListeners = [];
 
@@ -66,6 +67,7 @@ async function logout() {
     _stoptAutoLogoutTimer(); session.destroy(); 
     securityguard.setCurrentRole(APP_CONSTANTS.GUEST_ROLE);
     session.set($$.MONKSHU_CONSTANTS.LANG_ID, savedLang);
+    i18n.init(APP_CONSTANTS.APP_PATH);
 	application.main();
 }
 


### PR DESCRIPTION
## Issue

After logout, `session.destroy()` cleared Monkshu’s i18n app-path registry, causing login page `{{i18n.*}}` placeholders to render empty.

### Before

<img width="1246" height="532" alt="Screenshot 2026-05-14 at 12 23 30 PM" src="https://github.com/user-attachments/assets/b3bc41ef-6d92-4884-9d73-9dee4f88fe63" />


## Fix

Re-initialized i18n after `session.destroy()` to restore bundles before redirecting to the login page.

### After

<img width="1289" height="559" alt="Screenshot 2026-05-14 at 12 24 30 PM" src="https://github.com/user-attachments/assets/f5624eba-ea74-45cf-a86e-c8b4dc9b6ca2" />

